### PR TITLE
Add /etc/machine-id as mapped device

### DIFF
--- a/evcc-nightly/config.json
+++ b/evcc-nightly/config.json
@@ -32,5 +32,8 @@
   "7090/udp": "Keba",
   "8887/tcp": "OCPP web socket",
   "9522/udp": "Multicast (SMA Speedwire)"
-  }
+  },
+  "devices": [
+    "/etc/machine-id:/etc/machine-id:ro"
+  ]
 }

--- a/evcc/config.json
+++ b/evcc/config.json
@@ -33,5 +33,8 @@
   "7090/udp": "Keba",
   "8887/tcp": "OCPP web socket",
   "9522/udp": "Multicast (SMA Speedwire)"
-  }
+  },
+  "devices": [
+    "/etc/machine-id:/etc/machine-id:ro"
+  ]
 }


### PR DESCRIPTION
Add /etc/machine-id as mapped device because we need it for SHM, EEBus and the new telemetry feature