### PR TITLE
Add sqlite_file variable

### DIFF
--- a/evcc-nightly/config.json
+++ b/evcc-nightly/config.json
@@ -24,6 +24,7 @@
   },
   "host_network": true,
   "map": ["config:rw"],
+  "devices": ["/dev/ttyUSB0:/dev/ttyUSB0:rwm"],
   "webui": "http://[HOST]:[PORT:7070]/",
   "ports": {
   "7090/udp": 7090,

--- a/evcc-nightly/config.json
+++ b/evcc-nightly/config.json
@@ -15,10 +15,12 @@
   "init": false,
   "image": "andig/evcc",
   "options": {
-      "config_file": "/config/evcc.yaml"
+      "config_file": "/config/evcc.yaml",
+      "sqlite_file": "/data/evcc.db"
   },
   "schema":  {
-      "config_file": "str"
+      "config_file": "str",
+      "sqlite_file": "str"
   },
   "host_network": true,
   "map": ["config:rw"],

--- a/evcc-nightly/config.json
+++ b/evcc-nightly/config.json
@@ -24,7 +24,6 @@
   },
   "host_network": true,
   "map": ["config:rw"],
-  "devices": ["/dev/ttyUSB0:/dev/ttyUSB0:rwm"],
   "webui": "http://[HOST]:[PORT:7070]/",
   "ports": {
   "7090/udp": 7090,


### PR DESCRIPTION
Add sqlite_file variable, needed for evcc-io/evcc#4884. This should work for nightly as for now, because evcc-io/evcc#4884 has already been merged to master and current nightly builds exist:

Works for me
```
Using config file: /config/evcc.yaml
starting evcc: 'evcc --config /config/evcc.yaml --sqlite /data/evcc.db'
[main  ] INFO 2022/10/30 12:57:16 evcc 0.105.2 (c83e1099)
[main  ] INFO 2022/10/30 12:57:16 using config file: /config/evcc.yaml
[main  ] INFO 2022/10/30 12:57:16 listening at :7070
[db    ] TRACE 2022/10/30 12:57:17 SELECT count(*) FROM sqlite_master WHERE type='table' AND name="settings" -1 <nil>
[db    ] TRACE 2022/10/30 12:57:17 CREATE TABLE `settings` (`key` text,`value` text,PRIMARY KEY (`key`)) 0 <nil>
[db    ] TRACE 2022/10/30 12:57:17 SELECT * FROM `settings` 0 <nil>
[mqtt  ] INFO 2022/10/30 12:57:17 connecting evcc-1995696311 at tcp://192.168.4.5:1883
[mqtt  ] DEBUG 2022/10/30 12:57:18 tcp://192.168.4.5:1883 connected
```