### PR TITLE
Enable UART support for this addon

### DIFF
--- a/evcc-nightly/config.json
+++ b/evcc-nightly/config.json
@@ -24,6 +24,7 @@
   },
   "host_network": true,
   "map": ["config:rw"],
+  "devices": ["/dev/ttyUSB0:/dev/ttyUSB0:rwm"],
   "webui": "http://[HOST]:[PORT:7070]/",
   "ports": {
   "7090/udp": 7090,

--- a/evcc-nightly/config.json
+++ b/evcc-nightly/config.json
@@ -24,7 +24,6 @@
   },
   "host_network": true,
   "map": ["config:rw"],
-  "devices": ["/dev/ttyUSB0:/dev/ttyUSB0:rwm"],
   "webui": "http://[HOST]:[PORT:7070]/",
   "ports": {
   "7090/udp": 7090,


### PR DESCRIPTION
This PR is intended to fix evcc-io/evcc#3233
RS485-to-USB-Adapters connected to the Home Assistant OS Raspberry should be visible to evcc afterwards

Setting uart:true adds the following in the Docker config:
```
"DeviceCgroupRules": [
  "c 188:* rwm",
  "c 204:* rwm",
  "c 166:* rwm"
],
```
this enables access to the following devices:
```
 166 char	ACM USB modems
		  0 = /dev/ttyACM0	First ACM modem
		  1 = /dev/ttyACM1	Second ACM modem
		    ...
```
```
 188 char	USB serial converters
		  0 = /dev/ttyUSB0	First USB serial converter
		  1 = /dev/ttyUSB1	Second USB serial converter
		    ...
```
```
 204 char	Low-density serial ports
		  0 = /dev/ttyLU0		LinkUp Systems L72xx UART - port 0
		  1 = /dev/ttyLU1		LinkUp Systems L72xx UART - port 1
		  2 = /dev/ttyLU2		LinkUp Systems L72xx UART - port 2
		  3 = /dev/ttyLU3		LinkUp Systems L72xx UART - port 3
		  4 = /dev/ttyFB0		Intel Footbridge (ARM)
		  5 = /dev/ttySA0		StrongARM builtin serial port 0
		  6 = /dev/ttySA1		StrongARM builtin serial port 1
		  7 = /dev/ttySA2		StrongARM builtin serial port 2
		  8 = /dev/ttySC0		SCI serial port (SuperH) - port 0
		  9 = /dev/ttySC1		SCI serial port (SuperH) - port 1
		 10 = /dev/ttySC2		SCI serial port (SuperH) - port 2
		 11 = /dev/ttySC3		SCI serial port (SuperH) - port 3
		 12 = /dev/ttyFW0		Firmware console - port 0
		 13 = /dev/ttyFW1		Firmware console - port 1
		 14 = /dev/ttyFW2		Firmware console - port 2
		 15 = /dev/ttyFW3		Firmware console - port 3
		 16 = /dev/ttyAM0		ARM "AMBA" serial port 0
		    ...
		 31 = /dev/ttyAM15		ARM "AMBA" serial port 15
		 32 = /dev/ttyDB0		DataBooster serial port 0
		    ...
		 39 = /dev/ttyDB7		DataBooster serial port 7
		 40 = /dev/ttySG0		SGI Altix console port
		 41 = /dev/ttySMX0		Motorola i.MX - port 0
		 42 = /dev/ttySMX1		Motorola i.MX - port 1
		 43 = /dev/ttySMX2		Motorola i.MX - port 2
		 44 = /dev/ttyMM0		Marvell MPSC - port 0 (obsolete unused)
		 45 = /dev/ttyMM1		Marvell MPSC - port 1 (obsolete unused)
		 46 = /dev/ttyCPM0		PPC CPM (SCC or SMC) - port 0
		    ...
		 47 = /dev/ttyCPM5		PPC CPM (SCC or SMC) - port 5
		 50 = /dev/ttyIOC0		Altix serial card
		    ...
		 81 = /dev/ttyIOC31		Altix serial card
		 82 = /dev/ttyVR0		NEC VR4100 series SIU
		 83 = /dev/ttyVR1		NEC VR4100 series DSIU
		 84 = /dev/ttyIOC84		Altix ioc4 serial card
		    ...
		 115 = /dev/ttyIOC115		Altix ioc4 serial card
		 116 = /dev/ttySIOC0		Altix ioc3 serial card
		    ...
		 147 = /dev/ttySIOC31		Altix ioc3 serial card
		 148 = /dev/ttyPSC0		PPC PSC - port 0
		    ...
		 153 = /dev/ttyPSC5		PPC PSC - port 5
		 154 = /dev/ttyAT0		ATMEL serial port 0
		    ...
		 169 = /dev/ttyAT15		ATMEL serial port 15
		 170 = /dev/ttyNX0		Hilscher netX serial port 0
		    ...
		 185 = /dev/ttyNX15		Hilscher netX serial port 15
		 186 = /dev/ttyJ0		JTAG1 DCC protocol based serial port emulation
		 187 = /dev/ttyUL0		Xilinx uartlite - port 0
		    ...
		 190 = /dev/ttyUL3		Xilinx uartlite - port 3
		 191 = /dev/xvc0		Xen virtual console - port 0
		 192 = /dev/ttyPZ0		pmac_zilog - port 0
		    ...
		 195 = /dev/ttyPZ3		pmac_zilog - port 3
		 196 = /dev/ttyTX0		TX39/49 serial port 0
		    ...
		 204 = /dev/ttyTX7		TX39/49 serial port 7
		 205 = /dev/ttySC0		SC26xx serial port 0
		 206 = /dev/ttySC1		SC26xx serial port 1
		 207 = /dev/ttySC2		SC26xx serial port 2
		 208 = /dev/ttySC3		SC26xx serial port 3
		 209 = /dev/ttyMAX0		MAX3100 serial port 0
		 210 = /dev/ttyMAX1		MAX3100 serial port 1
		 211 = /dev/ttyMAX2		MAX3100 serial port 2
		 212 = /dev/ttyMAX3		MAX3100 serial port 3
```