### PR TITLE
Change Docker Hub Repo from andig/evcc to evcc/evcc

### DIFF
--- a/evcc-nightly/config.json
+++ b/evcc-nightly/config.json
@@ -13,7 +13,7 @@
   "ingress": true,
   "ingress_port": 7070,
   "init": false,
-  "image": "andig/evcc",
+  "image": "evcc/evcc",
   "options": {
       "config_file": "/config/evcc.yaml",
       "sqlite_file": "/data/evcc.db"

--- a/evcc/config.json
+++ b/evcc/config.json
@@ -14,7 +14,7 @@
   "ingress": true,
   "ingress_port": 7070,
   "init": false,
-  "image": "andig/evcc",
+  "image": "evcc/evcc",
   "options": {
       "config_file": "/config/evcc.yaml",
       "sqlite_file": "/data/evcc.db"


### PR DESCRIPTION
As announced in https://docs.evcc.io/blog/#-docker-image-zieht-um we should pull the docker images from the new evcc/evcc Docker Open Source Team