### PR TITLE
Fixing Sponsorship Links

### DIFF
--- a/evcc/README.md
+++ b/evcc/README.md
@@ -89,12 +89,16 @@ If you miss one of the above steps Gitub Actions will likely trigger a **Porcela
 
 ## Sponsorship
 
-evcc believes in open source software. We're committed to provide best in class EV charging experience.
-Maintaining evcc consumes time and effort. With the vast amount of different devices to support, we depend on community and vendor support to keep evcc alive.
+evcc believes in open source software.
+We're committed to provide best in class EV charging experience.
+Maintaining evcc consumes time and effort.
+With the vast amount of different devices to support, we depend on community and vendor support to keep evcc alive.
 
-While evcc is open source, we would also like to encourage vendors to provide open source hardware devices, public documentation and support open source projects like ours that provide additional value to otherwised closed hardware. Where this is not the case, evcc requires "sponsor token" to finance ongoing development and support of evcc.
+While evcc is open source, we would also like to encourage vendors to provide open source hardware devices, public documentation and support open source projects like ours that provide additional value to otherwise closed hardware. 
+Where this is not the case, evcc requires "sponsor token" to finance ongoing development and support of evcc.
 
-The personal sponsor token requires a [Github Sponsorship](https://github.com/sponsors/andig) and can be requested at [cloud.evcc.io](https://cloud.evcc.io/). A sponsor token is valid for one year and can be renewed any time with active sponsorship.
+The personal sponsor token requires a [Github Sponsorship](https://github.com/sponsors/evcc-io) and can be requested at [sponsor.evcc.io](https://sponsor.evcc.io/).
+A sponsor token is valid for one year and can be renewed any time with active sponsorship.
 
 ## Background
 


### PR DESCRIPTION
### What
- Updating Sponsorship links according to [evcc-io/evcc/README.md](https://github.com/evcc-io/evcc/blob/6808b8c23f4a2d7c71bfbd93c7e95ae8cf789a15/README.md?plain=1#L128)
- Fixed a typo.
- Also applied '[one sentence per line](https://nick.groenen.me/notes/one-sentence-per-line/)' technique to 'Sponsorship' section

### Why 
Few days ago, I initially sponsored 'andig', because I clicked the link in the Home Assistant Add-on's Description page.
When I didn't receive a sponsorhip token for hours, I realized I should've sponsored 'evcc-io' instead.
Luckily it was only $2 that went onto the wrong account.
(See also https://github.com/evcc-io/evcc readme.)