### PR TITLE
add "homeassistant_api: true" to config.yaml

### DIFF
--- a/evcc/config.yaml
+++ b/evcc/config.yaml
@@ -13,6 +13,7 @@ arch:
 startup: application
 panel_icon: mdi:ev-station
 panel_admin: false
+homeassistant_api: true
 boot: auto
 legacy: true
 stage: stable


### PR DESCRIPTION
Will allow evcc HA addon to make API calls to your homeassistant host using the HA supervisor. Removes the need for a long lived access token and a call to the IP adres of your. More info in the docs https://developers.home-assistant.io/docs/add-ons/communication/

Will make API call possible in this form from within the the evcc.io add-on docker container.
curl -X GET -H "Authorization: Bearer ${SUPERVISOR_TOKEN}" -H "Content-Type: application/json" http://supervisor/core/api

In evcc.yaml a custom http sensor would then should look something like this:

```
    source: http
      uri: http://supervisor/core/api/states/sensor.your_ha_sensorname
      method: GET
      headers:
        - Authorization: Bearer ${SUPERVISOR_TOKEN}
        - Content-Type: application/json insecure: true jq: ".state | tonumber" timeout: 2s
```

->I write should, because I haven't found a way to use the environment variable in evcc.yaml. I have confirmed it is availalble in the container and hard code the value will get the api to work. Anyone with more evcc or go experience with a tip on how to use ${SUPERVISOR_TOKEN} in evcc.yaml?

```

➜  ~ docker ps -a | grep evcc            
87927953e160   evcc/evcc:0.130.13                                              "/app/entrypoint.sh …"   7 minutes ago    Up 7 minutes (healthy)                                                                                                                                  addon_d1780fd2_evcc
➜  ~ docker exec -ti 87927953e160 /bin/sh
/app # evcc
[main  ] INFO 2024/10/19 15:24:58 evcc 0.130.13
[main  ] INFO 2024/10/19 15:24:58 missing config file - switching into demo mode
[db    ] INFO 2024/10/19 15:24:58 using sqlite database: /root/.evcc/evcc.db
[main  ] INFO 2024/10/19 15:24:58 listening at :7070
/app # ^C

/app # echo ${SUPERVISOR_TOKEN}
02634b7f3b1c13b6aab7983c431fd96e0bf8ab8a3057ec09e23964a1a34884ffa9a0596b612ab29a66a0b7bdb72625axxxxxxxxxxxxxxxxx

``

