### PR TITLE
Enable HA REST API proxy

### DIFF
--- a/evcc-nightly/config.yaml
+++ b/evcc-nightly/config.yaml
@@ -52,3 +52,4 @@ ports_description:
   8887/tcp: "OCPP web socket"
   8899/udp: "Modbus UDP"
   9522/udp: "SMA Speedwire Multicast"
+homeassistant_api: true

--- a/evcc/config.yaml
+++ b/evcc/config.yaml
@@ -52,3 +52,4 @@ ports_description:
   8887/tcp: "OCPP web socket"
   8899/udp: "Modbus UDP"
   9522/udp: "SMA Speedwire Multicast"
+homeassistant_api: true


### PR DESCRIPTION
By adding this line to the add-on configuration, we enable the internal proxy that exposes the HA REST API to the add-on.

In practice, this makes it possible to read the state of HA sensor via the `http://supervisor/core/api/` endpoint, using the authentication token supplied in the `SUPERVISOR_TOKEN` environment variable (cfr. [HA docs](https://developers.home-assistant.io/docs/add-ons/communication/#home-assistant-core)).

This effectively allows us to more easily integrate EVCC with HA, as you will no longer need to create long-lived tokens in HA to be able to read sensor data from it. For example: we could easily enable the use of HA entities in the Configuration UI.

Demo:

```bash
app # curl -X GET -H "Authorization: Bearer ${SUPERVISOR_TOKEN}" -H "Content-Type: application/json" http://supervisor/core/api/states/sensor.p1_meter_energy_import | jq
{
  "entity_id": "sensor.p1_meter_energy_import",
  "state": "6026.345",
  "attributes": {
    "state_class": "total_increasing",
    "unit_of_measurement": "kWh",
    "device_class": "energy",
    "friendly_name": "P1 Meter Energy import"
  },
  "last_changed": "2025-03-10T15:22:56.566781+00:00",
  "last_reported": "2025-03-10T15:42:11.567678+00:00",
  "last_updated": "2025-03-10T15:22:56.566781+00:00",
  "context": {
    "id": "01JP0ADSNPW2E01B35Y5XXGA2S",
    "parent_id": null,
    "user_id": null
  }
}

```

(jq and curl were installed into the add-on container for testing/demonstration purposes)