### PR TITLE
update evcc to 0.207.0

### DIFF
--- a/evcc/config.yaml
+++ b/evcc/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: evcc
-version: 0.206.1
+version: 0.207.0
 slug: evcc
 description: EV Charge Controller!
 url: https://github.com/evcc-io/evcc


### PR DESCRIPTION
This pull request updates the version of the `evcc` project in the configuration file to reflect the latest release.

* [`evcc/config.yaml`](diffhunk://#diff-ff24b8fabf4ffd5bef691d341d16fd7e300d159e706f53e70481b6d8a3d492b7L3-R3): Updated the `version` field from `0.206.1` to `0.207.0` to align with the new release version.