### PR TITLE
Add optional config value for SEMP_BASE_URL

### DIFF
--- a/evcc-nightly/config.yaml
+++ b/evcc-nightly/config.yaml
@@ -28,6 +28,7 @@ schema:
   config_file: str
   sqlite_file: str
   EVOPT_URI: url?
+  SEMP_BASE_URL: url?
 host_network: true
 homeassistant_api: true
 map: 

--- a/evcc-nightly/translations/en.yaml
+++ b/evcc-nightly/translations/en.yaml
@@ -19,3 +19,9 @@ configuration:
       Enter the full URL including protocol (e.g., for cloud https://evopt.evcc.io and local http://localhost:7050).
       Leave empty if not using EVopt features.
       Home Assistant Addon: https://github.com/thecem/hassio-evopt
+  SEMP_BASE_URL:
+    name: "SHM discovery URL"
+    description: >
+      For the SMA Home Manager to discover evcc, it needs to have the proper URL to inquire. This must be
+the external IP, e.g., http://192.168.123.234:7070 (the IP address with which Home Assistant is reachable from the SHM over the local network).
+      Leave empty if not using SMA Home Manager as a meter.

--- a/evcc/config.yaml
+++ b/evcc/config.yaml
@@ -28,6 +28,7 @@ schema:
   config_file: str
   sqlite_file: str
   EVOPT_URI: url?
+  SEMP_BASE_URL: url?
 host_network: true
 map: 
   - type: addon_config

--- a/evcc/translations/en.yaml
+++ b/evcc/translations/en.yaml
@@ -19,3 +19,8 @@ configuration:
       Enter the full URL including protocol (e.g., for cloud https://evopt.evcc.io and local http://localhost:7050).
       Leave empty if not using EVopt features.
       Home Assistant Addon: https://github.com/thecem/hassio-evopt
+  SEMP_BASE_URL:
+    name: "SHM discovery URL"
+    description: >
+      For the SMA Home Manager to discover evcc, it needs to have the proper URL to inquire. This must be the external IP, e.g., http://192.168.123.234:7070 (the IP address with which Home Assistant is reachable from the SHM over the local network).
+      Leave empty if not using SMA Home Manager as a meter.


### PR DESCRIPTION
This exposes the value added in https://github.com/evcc-io/evcc/pull/24876 that can be used to set a sensible SMA Home Manager base URL for discovery.