### PR TITLE
Fix declaration of EVCC_REMOTE_ACCESS

### DIFF
--- a/evcc-nightly/config.yaml
+++ b/evcc-nightly/config.yaml
@@ -21,7 +21,7 @@ schema:
   config_file: str?
   OPTIMIZER_URI: url?
   SEMP_BASE_URL: url?
-  EVCC_REMOTE_ACCESS: url?
+  EVCC_REMOTE_ACCESS: str
 host_network: true
 homeassistant_api: true
 map: 

--- a/evcc-nightly/config.yaml
+++ b/evcc-nightly/config.yaml
@@ -21,7 +21,7 @@ schema:
   config_file: str?
   OPTIMIZER_URI: url?
   SEMP_BASE_URL: url?
-  EVCC_REMOTE_ACCESS: str
+  EVCC_REMOTE_ACCESS: str?
 host_network: true
 homeassistant_api: true
 map: 


### PR DESCRIPTION
While api.evcc.cloud looks like an URL, it needs to be declared as string. It needs to be enteed without protocol designation. url? Would expect a trailing htt://or https:// designation and won‘t save without.