### PR TITLE
Bump version from 0.314.4 to 0.314.5

### DIFF
--- a/evcc/config.yaml
+++ b/evcc/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: evcc
-version: 0.314.4
+version: 0.314.5
 slug: evcc
 description: EV Charge Controller!
 url: https://github.com/evcc-io/evcc


### PR DESCRIPTION
Updates the stable Home Assistant add-on from evcc 0.314.4 to 0.314.5.

0.314.4 was tagged from the wrong branch and contains the 0.313.3 binary, as reported in evcc-io/evcc#33235.

0.314.5 contains the corrected release, but the Home Assistant add-on is still advertising 0.314.4.